### PR TITLE
chore: use `angular-kinvey` as bower name as `bower link` works

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "kinvey",
+    "name": "angular-kinvey",
     "version": "v1.1.0",
     "ignore": [
         "test/",


### PR DESCRIPTION
This shouldn't interfere with `pkg.name` as it's in the NPM namespace and it seems like you're not putting this on NPM anyway.
